### PR TITLE
Bumps widestring to v1 and makes sure we pass it an aligned ptr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 ddc = { version = "^0.2.0" }
 winapi = { version = "^0.3.5", features = ["windef", "minwindef", "winuser", "physicalmonitorenumerationapi", "lowlevelmonitorconfigurationapi"] }
-widestring = "^0.3.0"
+widestring = "1"

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -1,0 +1,13 @@
+extern crate ddc;
+use ddc::Ddc;
+
+extern crate ddc_winapi;
+use ddc_winapi::Monitor;
+
+fn main() {
+    let monitors = Monitor::enumerate().unwrap();
+    for mut m in monitors {
+        print!("{:?}: ", m);
+        println!("{:?}", m.get_timing_report());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use winapi::um::lowlevelmonitorconfigurationapi::*;
 use winapi::shared::windef::{HMONITOR, HDC, LPRECT};
 use winapi::shared::minwindef::{LPARAM, BYTE, DWORD, BOOL, TRUE};
 use winapi::um::winnt::HANDLE;
-use widestring::WideCString;
+use widestring::WideCStr;
 use ddc::{Ddc, DdcHost, FeatureCode, VcpValue, TimingMessage};
 
 // TODO: good luck getting EDID: https://social.msdn.microsoft.com/Forums/vstudio/en-US/efc46c70-7479-4d59-822b-600cb4852c4b/how-to-locate-the-edid-data-folderkey-in-the-registry-which-belongs-to-a-specific-physicalmonitor?forum=wdk
@@ -60,9 +60,15 @@ impl Monitor {
 
     /// Physical monitor description string.
     pub fn description(&self) -> String {
-        unsafe {
-            WideCString::from_ptr_str(self.monitor.szPhysicalMonitorDescription.as_ptr())
-                .to_string_lossy()
+        let str_ptr = ptr::addr_of!(self.monitor.szPhysicalMonitorDescription);
+        // TODO: Replace with is_aligned() once it's stable
+        let is_aligned = (str_ptr as usize) & (mem::align_of::<u16>() - 1) == 0;
+        if is_aligned {
+            unsafe { WideCStr::from_ptr_str(str_ptr as _) }.to_string_lossy()
+        } else {
+            let aligned = unsafe { ptr::read_unaligned(str_ptr) };
+            let wide_str = unsafe { WideCStr::from_ptr_str(aligned.as_ptr()) };
+            wide_str.to_string_lossy()
         }
     }
 


### PR DESCRIPTION
Hey there!

Following up after https://github.com/arcnmx/ddc-winapi-rs/pull/1, this time I kept the changes to a minimum, so just the dep bump (this time to v1 🎉) and now properly checking the ptr we pass to WideCStr::from_ptr_str is aligned.